### PR TITLE
added check for readaccess to file

### DIFF
--- a/mat-gui
+++ b/mat-gui
@@ -330,6 +330,8 @@ non-anonymised) file to output archive'))
         for item in filelist:
             if os.path.splitext(item)[1] in parser.NOMETA:
                 store.append([os.path.basename(item), _('Harmless fileformat')])
+            elif not os.access(item, os.R_OK):
+                store.append([os.path.basename(item), _('Cant read file')])
             else:
                 store.append([os.path.basename(item), _('Fileformat not supported')])
 


### PR DESCRIPTION
mat-gui isn't very open about the reason why it cannot process files. this is a small patch to check if a file is at least readable (which is also checked in create_class_file but not communicated).